### PR TITLE
Fix Terraform validation errors:

### DIFF
--- a/azure/terraform/modules/container_apps/main.tf
+++ b/azure/terraform/modules/container_apps/main.tf
@@ -86,9 +86,25 @@ resource "azurerm_container_app" "xhuma" {
   
   # Use username/password authentication for ACR instead of managed identity
   registry {
+    server               = var.acr_login_server
+  }
+  
+  # Add registry credentials separately - this is the correct syntax for container apps
+  secret {
+    name  = "registry-password"
+    value = var.acr_admin_password
+  }
+  
+  # Refer to the registry credentials from the secret
+  identity {
+    type = "None"
+  }
+  
+  # Add registry auth
+  registry_credential {
     server   = var.acr_login_server
     username = var.acr_admin_username
-    password = var.acr_admin_password
+    password_secret_name = "registry-password"
   }
 }
 

--- a/azure/terraform/modules/storage/main.tf
+++ b/azure/terraform/modules/storage/main.tf
@@ -9,11 +9,11 @@ resource "azurerm_storage_account" "storage" {
   tags                     = var.tags
   
   # Security settings
-  min_tls_version            = "TLS1_2"
-  https_traffic_only_enabled = true  # Updated from deprecated enable_https_traffic_only
+  min_tls_version           = "TLS1_2"
+  enable_https_traffic_only = true  # Using the supported attribute name
   # Removed deprecated allow_blob_public_access attribute
   # Using newer attribute to maintain the same security level
-  shared_access_key_enabled  = true  # Enabled to allow access via storage keys
+  shared_access_key_enabled = true  # Enabled to allow access via storage keys
 }
 
 # Create file shares for Redis and PostgreSQL data


### PR DESCRIPTION
1. Change https_traffic_only_enabled to enable_https_traffic_only in storage module
2. Fix registry authentication in container apps using proper secret and registry_credential blocks