### PR TITLE
Fix Container App registry authentication

### DIFF
--- a/azure/terraform/modules/container_apps/main.tf
+++ b/azure/terraform/modules/container_apps/main.tf
@@ -86,25 +86,9 @@ resource "azurerm_container_app" "xhuma" {
   
   # Use username/password authentication for ACR instead of managed identity
   registry {
-    server               = var.acr_login_server
-  }
-  
-  # Add registry credentials separately - this is the correct syntax for container apps
-  secret {
-    name  = "registry-password"
-    value = var.acr_admin_password
-  }
-  
-  # Refer to the registry credentials from the secret
-  identity {
-    type = "None"
-  }
-  
-  # Add registry auth
-  registry_credential {
     server   = var.acr_login_server
     username = var.acr_admin_username
-    password_secret_name = "registry-password"
+    password = var.acr_admin_password
   }
 }
 


### PR DESCRIPTION
1. Simplified registry authentication for Azure Container Apps
2. Removed unsupported 'registry_credential' block that was causing Terraform validation failures
3. Reverted to the simple registry block with direct username/password approach
4. Removed unnecessary secret and identity blocks