### PR TITLE
Fix Container App registry authentication - Take 2

### DIFF
--- a/azure/terraform/modules/container_apps/main.tf
+++ b/azure/terraform/modules/container_apps/main.tf
@@ -84,11 +84,9 @@ resource "azurerm_container_app" "xhuma" {
     }
   }
   
-  # Use username/password authentication for ACR instead of managed identity
+  # Reference the container registry by URL only, without authentication parameters
   registry {
-    server   = var.acr_login_server
-    username = var.acr_admin_username
-    password = var.acr_admin_password
+    server = var.acr_login_server
   }
 }
 


### PR DESCRIPTION
1. Removed all authentication parameters from registry block
2. Now only referencing the ACR server URL without credentials
3. This approach should be compatible with the current Azure provider version
4. May require ACR to be set as public or use managed identity auth in the future