### PR TITLE
Add skip_provider_registration flag to Azure provider

### DIFF
--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -18,6 +18,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
   # Note: Tenant and subscription should be set via az CLI before running Terraform
   # az login --tenant uclhaz.onmicrosoft.com
   # az account set --subscription rg-xhuma-play


### PR DESCRIPTION
1. Added skip_provider_registration = true to the Azure provider configuration
2. This prevents Terraform from trying to register Azure Resource Providers
3. Resolves the 'Microsoft.TimeSeriesInsights' provider registration error
4. Helps when the service principal has limited permissions