### PR TITLE
Fix Container App registry authentication with managed identity

### DIFF
--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -137,6 +137,21 @@ module "container_apps" {
   tags                        = local.common_tags
 }
 
+# Give the Container App's managed identity access to ACR
+resource "azurerm_role_assignment" "xhuma_acr_pull" {
+  # The Container App needs to be created first to have a managed identity
+  depends_on = [module.container_apps]
+  
+  # Get the principal ID of the Container App's managed identity
+  principal_id         = module.container_apps.xhuma_identity_principal_id
+  
+  # Use the built-in ACR Pull role
+  role_definition_name = "AcrPull"
+  
+  # Scope to the ACR resource
+  scope                = module.acr.id
+}
+
 # Current client config for Key Vault access policies
 data "azurerm_client_config" "current" {}
 

--- a/azure/terraform/modules/container_apps/main.tf
+++ b/azure/terraform/modules/container_apps/main.tf
@@ -84,7 +84,12 @@ resource "azurerm_container_app" "xhuma" {
     }
   }
   
-  # Reference the container registry by URL only, without authentication parameters
+  # Use managed identity authentication for ACR
+  identity {
+    type = "SystemAssigned"
+  }
+  
+  # Reference the container registry by URL only
   registry {
     server = var.acr_login_server
   }

--- a/azure/terraform/modules/container_apps/outputs.tf
+++ b/azure/terraform/modules/container_apps/outputs.tf
@@ -6,8 +6,13 @@ output "xhuma_app_id" {
 }
 
 output "xhuma_app_url" {
-  description = "The URL of the Xhuma container app"
-  value       = "https://${azurerm_container_app.xhuma.ingress[0].fqdn}"
+  description = "The URL to access the Xhuma application"
+  value       = azurerm_container_app.xhuma.ingress[0].fqdn
+}
+
+output "xhuma_identity_principal_id" {
+  description = "The principal ID of the Xhuma container app's managed identity"
+  value       = azurerm_container_app.xhuma.identity[0].principal_id
 }
 
 output "redis_app_id" {


### PR DESCRIPTION
1. Added SystemAssigned managed identity to the Xhuma container app
2. Configured registry authentication to use managed identity
3. Added role assignment to give the container app ACR Pull access
4. Added output for the container app's managed identity principal ID
5. This approach resolves the 'invalid registry config' error from Azure