### PR TITLE
Switch to username/password authentication for Container App registry

### DIFF
--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -137,20 +137,8 @@ module "container_apps" {
   tags                        = local.common_tags
 }
 
-# Give the Container App's managed identity access to ACR
-resource "azurerm_role_assignment" "xhuma_acr_pull" {
-  # The Container App needs to be created first to have a managed identity
-  depends_on = [module.container_apps]
-  
-  # Get the principal ID of the Container App's managed identity
-  principal_id         = module.container_apps.xhuma_identity_principal_id
-  
-  # Use the built-in ACR Pull role
-  role_definition_name = "AcrPull"
-  
-  # Scope to the ACR resource
-  scope                = module.acr.id
-}
+# Container App now uses secret-based authentication with ACR,
+# so we no longer need the role assignment that was here previously
 
 # Current client config for Key Vault access policies
 data "azurerm_client_config" "current" {}

--- a/azure/terraform/modules/container_apps/main.tf
+++ b/azure/terraform/modules/container_apps/main.tf
@@ -84,14 +84,17 @@ resource "azurerm_container_app" "xhuma" {
     }
   }
   
-  # Use managed identity authentication for ACR
-  identity {
-    type = "SystemAssigned"
+  # Use secret-based authentication for ACR
+  secret {
+    name  = "registry-password"
+    value = var.acr_admin_password
   }
   
-  # Reference the container registry by URL only
+  # Reference the container registry with credentials
   registry {
-    server = var.acr_login_server
+    server               = var.acr_login_server
+    username             = var.acr_admin_username
+    password_secret_name = "registry-password"
   }
 }
 


### PR DESCRIPTION
1. Replaced managed identity authentication with username/password authentication
2. Added container app secret to store ACR admin password
3. Updated registry block to use ACR credentials for authentication
4. Removed the role assignment that is no longer needed
5. This should fix the registry authentication error