### PR TITLE
Welp, old references.

### DIFF
--- a/azure/terraform/modules/container_apps/outputs.tf
+++ b/azure/terraform/modules/container_apps/outputs.tf
@@ -10,10 +10,8 @@ output "xhuma_app_url" {
   value       = azurerm_container_app.xhuma.ingress[0].fqdn
 }
 
-output "xhuma_identity_principal_id" {
-  description = "The principal ID of the Xhuma container app's managed identity"
-  value       = azurerm_container_app.xhuma.identity[0].principal_id
-}
+# Removed xhuma_identity_principal_id output since we're now using secret-based authentication
+# instead of managed identity authentication
 
 output "redis_app_id" {
   description = "The ID of the Redis container app"


### PR DESCRIPTION
1. Removed xhuma_identity_principal_id output since it's no longer applicable
2. Added a comment explaining the removal
3. This fixes the 'Error: Invalid index' that was occurring during Terraform plan
4. This completes the transition to secret-based authentication