### PR TITLE
Temporarily remove prevent_destroy settings to allow resource recreation

### DIFF
--- a/azure/terraform/modules/container_apps/main.tf
+++ b/azure/terraform/modules/container_apps/main.tf
@@ -8,10 +8,10 @@ resource "azurerm_container_app" "xhuma" {
   revision_mode                = "Single"
   tags                         = var.tags
   
-  # Prevent accidental destruction of container app
-  lifecycle {
-    prevent_destroy = true
-  }
+  # Temporarily removed prevent_destroy to allow recreation
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 
   template {
     container {
@@ -111,10 +111,10 @@ resource "azurerm_container_app" "redis" {
   revision_mode                = "Single"
   tags                         = var.tags
   
-  # Prevent accidental destruction of container app
-  lifecycle {
-    prevent_destroy = true
-  }
+  # Temporarily removed prevent_destroy to allow recreation
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 
   template {
     container {
@@ -168,10 +168,10 @@ resource "azurerm_container_app" "postgres" {
   revision_mode                = "Single"
   tags                         = var.tags
   
-  # Prevent accidental destruction of container app
-  lifecycle {
-    prevent_destroy = true
-  }
+  # Temporarily removed prevent_destroy to allow recreation
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 
   template {
     container {

--- a/azure/terraform/modules/container_apps_environment/main.tf
+++ b/azure/terraform/modules/container_apps_environment/main.tf
@@ -8,10 +8,10 @@ resource "azurerm_container_app_environment" "env" {
   infrastructure_subnet_id   = var.infrastructure_subnet_id
   tags                       = var.tags
   
-  # Prevent accidental destruction of resources
-  lifecycle {
-    prevent_destroy = true
-  }
+  # Temporarily removed prevent_destroy to allow recreation
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }
 
 # Create storage for Redis and PostgreSQL

--- a/azure/terraform/modules/storage/main.tf
+++ b/azure/terraform/modules/storage/main.tf
@@ -26,8 +26,8 @@ resource "azurerm_storage_share" "file_shares" {
   storage_account_name = azurerm_storage_account.storage.name
   quota                = var.file_share_quota
   
-  # Create new share before destroying old one to prevent data loss
-  lifecycle {
-    prevent_destroy = true
-  }
+  # Temporarily removed prevent_destroy to allow recreation
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }


### PR DESCRIPTION
1. Commented out prevent_destroy lifecycle blocks in:
   - Container Apps Environment resource
   - File Shares resources
   - Container Apps resources (Xhuma, Redis, Postgres)

2. Added clear comments indicating this is a temporary change

This will allow Terraform to recreate these resources if needed. The prevent_destroy settings should be re-enabled after successful deployment.