### PR TITLE
Fix token retrieval in PDS client

### DIFF
--- a/app/pds/pds.py
+++ b/app/pds/pds.py
@@ -37,6 +37,7 @@ async def lookup_patient(nhsno: int):
         nhs_token = response_dict["access_token"]
 
         redis_client.setex("access_token", response_dict["expires_in"], nhs_token)
+        return nhs_token
 
     # if nhs token expired or not request, get one and cache
     if not redis_client.exists("access_token"):


### PR DESCRIPTION
## Summary
- return the access token from `get_pds_token`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
