### PR TITLE
fix: allow robots.txt to bypass mTLS to prevent health check 403s

### DIFF
--- a/app/middleware/mtls.py
+++ b/app/middleware/mtls.py
@@ -83,6 +83,7 @@ class MTLSMiddleware(BaseHTTPMiddleware):
             "/health",
             "/_dev/audit",
             "/favicon.ico",
+            "/robots",
         ]
 
         is_public = (request.url.path == "/") or any(


### PR DESCRIPTION
This PR ensures that the Azure App Service health check pings to `/robots933456.txt` are excluded from the global mTLS middleware enforcement.