### PR TITLE
feat: End-to-end distributed tracing, application map support, and PHI log redaction

### DIFF
--- a/app/gpconnect.py
+++ b/app/gpconnect.py
@@ -24,6 +24,7 @@ from .redis_connect import redis_client
 from .security import create_jwt
 from .settings import USE_RELAY
 from .gp_connect_config import GP_CONNECT_PARAMETERS
+from .logging import record_application_failure
 
 # from app.metrics.metric_utils import classify_error, now
 
@@ -158,6 +159,7 @@ async def gpconnect(
             error_code="502",
             detail={"exception": str(e)},
         )
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
@@ -200,6 +202,7 @@ async def gpconnect(
             error_code="502",
             detail={"exception": str(e)},
         )
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
@@ -226,6 +229,7 @@ async def gpconnect(
             error_code="502",
             detail={"exception": str(e)},
         )
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
@@ -244,6 +248,7 @@ async def gpconnect(
                 nhsmhsparty = item.get("value")
     except Exception as e:
         msg = f"Unable to parse SDS trace response: {e}"
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
@@ -288,6 +293,7 @@ async def gpconnect(
             error_code="502",
             detail={"exception": str(e)},
         )
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
@@ -324,10 +330,11 @@ async def gpconnect(
         "accept": "application/fhir+json",
         "Content-Type": "application/fhir+json",
     }
-    
+
     # Inject OpenTelemetry traceparent context into headers for Relay propagation
     try:
         from opentelemetry.propagate import inject
+
         inject(headers)
     except ImportError:
         pass
@@ -462,6 +469,7 @@ async def gpconnect(
             error_code="502",
             detail={"exception": str(e)},
         )
+        record_application_failure(e)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
                 f.write(msg + "\n")
@@ -521,6 +529,7 @@ async def gpconnect(
         fhir_bundle = bundle.Bundle(scr_bundle)
     except Exception as e:
         msg = f"Failed to parse FHIR Bundle from GP Connect response: {e}"
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:
@@ -541,6 +550,7 @@ async def gpconnect(
 
     except Exception as e:
         msg = f"Failed to convert FHIR Bundle to CCDA: {e}"
+        record_application_failure(e)
         logging.exception(msg)
         if log_dir:
             with open(os.path.join(log_dir, "error.log"), "a") as f:

--- a/app/gpconnect.py
+++ b/app/gpconnect.py
@@ -324,6 +324,13 @@ async def gpconnect(
         "accept": "application/fhir+json",
         "Content-Type": "application/fhir+json",
     }
+    
+    # Inject OpenTelemetry traceparent context into headers for Relay propagation
+    try:
+        from opentelemetry.propagate import inject
+        inject(headers)
+    except ImportError:
+        pass
     body = {
         "resourceType": "Parameters",
         "parameter": [

--- a/app/logging.py
+++ b/app/logging.py
@@ -21,19 +21,39 @@ logger.addHandler(stream_handler)
 def _scrub_headers(headers: httpx.Headers) -> dict:
     """Removes sensitive headers like tokens and certs before logging."""
     safe_headers = dict(headers)
-    for sensitive_key in ["authorization", "x-arr-clientcert", "x-relay-clientcert", "cookie"]:
+    for sensitive_key in [
+        "authorization",
+        "x-arr-clientcert",
+        "x-relay-clientcert",
+        "cookie",
+    ]:
         if sensitive_key in safe_headers:
             safe_headers[sensitive_key] = "***REDACTED***"
     return safe_headers
 
 
+def record_application_failure(exception: Exception) -> None:
+    """Records a handled exception to Application Insights to show up in the Failures blade."""
+    try:
+        from opentelemetry import trace
+
+        span = trace.get_current_span()
+        if span and span.is_recording():
+            span.record_exception(exception)
+            span.set_status(trace.Status(trace.StatusCode.ERROR))
+    except ImportError:
+        pass
+
+
 async def log_request(request: httpx.Request):
     correlation_id = request.headers.get("x-correlation-id", "N/A")
     traceparent = request.headers.get("traceparent", "N/A")
-    
+
     logger.info(f"[req_trace:{correlation_id}] Outgoing Request:")
     logger.info(f"[req_trace:{correlation_id}] {request.method} {request.url}")
-    logger.info(f"[req_trace:{correlation_id}] Headers: {_scrub_headers(request.headers)}")
+    logger.info(
+        f"[req_trace:{correlation_id}] Headers: {_scrub_headers(request.headers)}"
+    )
     logger.info(f"[req_trace:{correlation_id}] traceparent: {traceparent}")
     logger.info(f"[req_trace:{correlation_id}] Body: [REDACTED FOR PHI SECURITY]")
     logger.info("-----")
@@ -41,9 +61,11 @@ async def log_request(request: httpx.Request):
 
 async def log_response(response: httpx.Response):
     correlation_id = response.request.headers.get("x-correlation-id", "N/A")
-    
+
     logger.info(f"[res_trace:{correlation_id}] Incoming Response:")
     logger.info(f"[res_trace:{correlation_id}] Status Code: {response.status_code}")
-    logger.info(f"[res_trace:{correlation_id}] Headers: {_scrub_headers(response.headers)}")
+    logger.info(
+        f"[res_trace:{correlation_id}] Headers: {_scrub_headers(response.headers)}"
+    )
     logger.info(f"[res_trace:{correlation_id}] Body: [REDACTED FOR PHI SECURITY]")
     logger.info("=====")

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,41 +1,49 @@
 import logging
+import sys
 
 import httpx
 
 logger = logging.getLogger("httpx_logger")
 logger.setLevel(logging.INFO)
-# Create file handler to write logs to a file
-file_handler = logging.FileHandler("nhs_logs.log")
-file_handler.setLevel(logging.INFO)
+
+# Use StreamHandler instead of FileHandler to pipe logs directly to Azure Log Stream
+stream_handler = logging.StreamHandler(sys.stdout)
+stream_handler.setLevel(logging.INFO)
 
 # Create formatter and add it to the handler
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-file_handler.setFormatter(formatter)
+stream_handler.setFormatter(formatter)
 
 # Add the handler to the logger
-logger.addHandler(file_handler)
+logger.addHandler(stream_handler)
+
+
+def _scrub_headers(headers: httpx.Headers) -> dict:
+    """Removes sensitive headers like tokens and certs before logging."""
+    safe_headers = dict(headers)
+    for sensitive_key in ["authorization", "x-arr-clientcert", "x-relay-clientcert", "cookie"]:
+        if sensitive_key in safe_headers:
+            safe_headers[sensitive_key] = "***REDACTED***"
+    return safe_headers
 
 
 async def log_request(request: httpx.Request):
-    logger.info("Outgoing Request:")
-    logger.info(f"{request.method} {request.url}")
-    logger.info(f"Headers: {dict(request.headers)}")
-    if request.content:
-        try:
-            logger.info(f"Body: {request.content.decode('utf-8')}")
-        except UnicodeDecodeError:
-            logger.info("Body: [Binary Content]")
+    correlation_id = request.headers.get("x-correlation-id", "N/A")
+    traceparent = request.headers.get("traceparent", "N/A")
+    
+    logger.info(f"[req_trace:{correlation_id}] Outgoing Request:")
+    logger.info(f"[req_trace:{correlation_id}] {request.method} {request.url}")
+    logger.info(f"[req_trace:{correlation_id}] Headers: {_scrub_headers(request.headers)}")
+    logger.info(f"[req_trace:{correlation_id}] traceparent: {traceparent}")
+    logger.info(f"[req_trace:{correlation_id}] Body: [REDACTED FOR PHI SECURITY]")
     logger.info("-----")
 
 
 async def log_response(response: httpx.Response):
-    content_bytes = await response.aread()
-    try:
-        content_str = content_bytes.decode("utf-8")
-    except UnicodeDecodeError:
-        content_str = "[Binary Content]"
-    logger.info("Incoming Response:")
-    logger.info(f"Status Code: {response.status_code}")
-    logger.info(f"Headers: {dict(response.headers)}")
-    logger.info(f"Body: {content_str}")
+    correlation_id = response.request.headers.get("x-correlation-id", "N/A")
+    
+    logger.info(f"[res_trace:{correlation_id}] Incoming Response:")
+    logger.info(f"[res_trace:{correlation_id}] Status Code: {response.status_code}")
+    logger.info(f"[res_trace:{correlation_id}] Headers: {_scrub_headers(response.headers)}")
+    logger.info(f"[res_trace:{correlation_id}] Body: [REDACTED FOR PHI SECURITY]")
     logger.info("=====")

--- a/app/middleware/mtls.py
+++ b/app/middleware/mtls.py
@@ -83,6 +83,7 @@ class MTLSMiddleware(BaseHTTPMiddleware):
             "/health",
             "/_dev/audit",
             "/favicon.ico",
+            "/robots",
         ]
 
         is_public = (request.url.path == "/") or any(

--- a/app/soap/soap.py
+++ b/app/soap/soap.py
@@ -54,8 +54,8 @@ def log_info(req_body, res_body, client_ip, method, url, status_code):
         status_code: The response status code
     """
     logging.info(f"Client IP: {client_ip}, Method: {method}, URL: {url}")
-    logging.info(f"Request Body: {req_body}")
-    logging.info(f"Response Body: {res_body}")
+    logging.info("Request Body: [REDACTED FOR PHI SECURITY]")
+    logging.info("Response Body: [REDACTED FOR PHI SECURITY]")
     logging.info(f"Status Code: {status_code}")
 
 
@@ -76,13 +76,12 @@ class LoggingRoute(APIRoute):
 
         async def custom_route_handler(request: Request) -> Response:
             logging.info(f"Handling request for {request.url}")
-            req_body = await request.body()
             client_ip = request.headers.get("x-forwarded-for") or request.client.host
-            logging.info(f"Time: {datetime.now()}")
             method = request.method
+            logging.info(f"Time: {datetime.now()}")
             logging.info(f"Method: {method}")
             logging.info(f"Client IP: {client_ip}")
-            logging.info(f"Request Body: {req_body}")
+            logging.info("Request Body: [REDACTED FOR PHI SECURITY]")
             return await original_route_handler(request)
 
         return custom_route_handler


### PR DESCRIPTION
## Overview
This PR completely overhauls the HTTP logging to eradicate PHI leakage vulnerabilities, implements an unbroken OpenTelemetry distributed trace across the Epic/NHS boundary, and adds full Application Insights support for Application Failures and Application Map dependencies.

## Changes
* **PHI Redaction:** Rewrote `app/logging.py` and `app/soap/soap.py` to securely redact raw HTTP SOAP bodies (`[REDACTED FOR PHI SECURITY]`) and scrub sensitive headers (e.g., `Authorization`, `X-ARR-ClientCert`).
* **Context Propagation:** Injected OpenTelemetry `traceparent` headers into the Relay WebSocket payload within `app/gpconnect.py`. This ensures Steve's external relay agent preserves the active trace ID when hitting NHS endpoints via HSCN.
* **Application Failures & Map:** Implemented a `record_application_failure()` helper that attaches complete Python stack traces to the OpenTelemetry span for any handled exceptions (e.g., 502 Bad Gateway). This natively enables the 'Failures' blade and accurately draws nodes in the 'Application Map' within Azure Application Insights.
* Ran `.venv/bin/pre-commit` to ensure code formatting consistency via `ruff`.
