### PR TITLE
feat: implement dynamic JWKS endpoint and cleanup mTLS troubleshooting

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -79,7 +79,10 @@ async def lifespan(app: FastAPI):
 
             private_pem = fix_pem_formatting(jwt_key).encode("utf-8")
             public_jwk = jwk.JWK.from_pem(private_pem)
-            app.state.jwk_json = public_jwk.export_public(as_dict=True)
+            jwk_dict = public_jwk.export_public(as_dict=True)
+            jwk_dict["alg"] = "RS512"
+            jwk_dict["use"] = "sig"
+            app.state.jwk_json = jwk_dict
         except Exception as e:
             print(f"Warning: Failed to load JWTKEY from environment: {e}")
     elif os.getenv("ENV", "prod").lower() in ("dev", "local") and os.path.isfile(
@@ -92,7 +95,10 @@ async def lifespan(app: FastAPI):
         with open("keys/test-1.pem", "rb") as pemfile:
             private_pem = pemfile.read()
             public_jwk = jwk.JWK.from_pem(data=private_pem)
-            app.state.jwk_json = public_jwk.export_public(as_dict=True)
+            jwk_dict = public_jwk.export_public(as_dict=True)
+            jwk_dict["alg"] = "RS512"
+            jwk_dict["use"] = "sig"
+            app.state.jwk_json = jwk_dict
     else:
         print(
             "Warning: No JWTKEY provided and not in dev/local mode. /jwk endpoint will return an error."
@@ -214,6 +220,25 @@ async def health_check():
     return {"status": "ok"}
 
 
+@app.get("/.well-known/jwks.json")
+async def jwks():
+    """
+    Host the public key (JWKS) for NHS PDS authentication.
+    """
+    return {
+        "keys": [
+            {
+                "kty": "RSA",
+                "n": "qegZcESaBQAGOYIbd3_9RH_oP-fltrCGNmHXwHgUUONAcQEQ0TBypzF3ktbdytKutZ072i_VHVzROH8wlHfWVJGdt0TKbJh2HCQTy8-ovMjSmbA5JfaEDSFMoJ3xPEu3aHrfHR6sHpB3KwQ1L-6WzNKTk0qXJQGjor691SFEdh4CoDxdcLDMpRwDIvIMnX4BD-EY3uih1W2Wiwc25V3FDJpSD0qhfCb1FcY3-z4vfEC47oI_UM1FYekal2wnHyXYUXchJar9HJh5ttelmcpAuOinbTrbi3ttovrsNHGriXwv5GiHkWsGGLQaj9b5SgBHBEgGgnrkyr1Rl5gLr1QNmq5LhGm1nA3JZzumwlmsiacA-tYCtPdMEG53Z1XuOAnBAV5Ee8PQarB85yKu1vWFCS1Tl8jpKvgHSD0sdInXFT_bZKUQhYiZ4FlF6F1ya8VL7wO6kKlwvP4f1iRgEzxRGGUyQrXK2cHfQAY-JEKlZ1R6hPcua-soJ11MKxaIjJClSJYlBkyDg_VhHFklRTaw_hsWiLyMaTyUvLvzGSBhF2nqO7dLLa4IIoar0Guv_srHFhWczUX37by_I9RCxFP0WfJcC_V4opQ3pXgAGMtd6TLnYXi2uiT8nGG_tnBChsZPtLd_C99wQ5kae2Ul_goJk68__5ZxGbR6k_mklxg98f0",
+                "e": "AQAB",
+                "alg": "RS512",
+                "kid": "test-1",
+                "use": "sig",
+            }
+        ]
+    }
+
+
 @app.get("/demo/{nhsno}")
 async def demo(nhsno: int, request: Request):
     """
@@ -278,10 +303,10 @@ async def get_jwk(request: Request):
     trust with the service.
 
     Returns:
-        dict: JSON Web Key in dictionary format.
+        dict: JSON Web Key Set in dictionary format.
     """
     if hasattr(request.app.state, "jwk_json") and request.app.state.jwk_json:
-        return request.app.state.jwk_json
+        return {"keys": [request.app.state.jwk_json]}
     return {"error": "JWK not configured on this server"}
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -220,25 +220,6 @@ async def health_check():
     return {"status": "ok"}
 
 
-@app.get("/.well-known/jwks.json")
-async def jwks():
-    """
-    Host the public key (JWKS) for NHS PDS authentication.
-    """
-    return {
-        "keys": [
-            {
-                "kty": "RSA",
-                "n": "qegZcESaBQAGOYIbd3_9RH_oP-fltrCGNmHXwHgUUONAcQEQ0TBypzF3ktbdytKutZ072i_VHVzROH8wlHfWVJGdt0TKbJh2HCQTy8-ovMjSmbA5JfaEDSFMoJ3xPEu3aHrfHR6sHpB3KwQ1L-6WzNKTk0qXJQGjor691SFEdh4CoDxdcLDMpRwDIvIMnX4BD-EY3uih1W2Wiwc25V3FDJpSD0qhfCb1FcY3-z4vfEC47oI_UM1FYekal2wnHyXYUXchJar9HJh5ttelmcpAuOinbTrbi3ttovrsNHGriXwv5GiHkWsGGLQaj9b5SgBHBEgGgnrkyr1Rl5gLr1QNmq5LhGm1nA3JZzumwlmsiacA-tYCtPdMEG53Z1XuOAnBAV5Ee8PQarB85yKu1vWFCS1Tl8jpKvgHSD0sdInXFT_bZKUQhYiZ4FlF6F1ya8VL7wO6kKlwvP4f1iRgEzxRGGUyQrXK2cHfQAY-JEKlZ1R6hPcua-soJ11MKxaIjJClSJYlBkyDg_VhHFklRTaw_hsWiLyMaTyUvLvzGSBhF2nqO7dLLa4IIoar0Guv_srHFhWczUX37by_I9RCxFP0WfJcC_V4opQ3pXgAGMtd6TLnYXi2uiT8nGG_tnBChsZPtLd_C99wQ5kae2Ul_goJk68__5ZxGbR6k_mklxg98f0",
-                "e": "AQAB",
-                "alg": "RS512",
-                "kid": "test-1",
-                "use": "sig",
-            }
-        ]
-    }
-
-
 @app.get("/demo/{nhsno}")
 async def demo(nhsno: int, request: Request):
     """

--- a/app/middleware/mtls.py
+++ b/app/middleware/mtls.py
@@ -63,22 +63,6 @@ def _verify_epic_cert(client_cert_b64: str) -> bool:
         f"Epic CA Verification: Loaded {len(ca_certs)} CA certificates from Key Vault",
         flush=True,
     )
-    try:
-        print(
-            f"Epic CA Verification: Client cert issuer: {client_cert.issuer.rfc4514_string()}",
-            flush=True,
-        )
-    except Exception:
-        pass
-
-    for i, ca_cert in enumerate(ca_certs):
-        try:
-            print(
-                f"Epic CA Verification: Checking CA {i} subject: {ca_cert.subject.rfc4514_string()}",
-                flush=True,
-            )
-        except Exception:
-            pass
 
     # Check expiry
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -152,14 +136,6 @@ class MTLSMiddleware(BaseHTTPMiddleware):
         # Bypass all global mTLS checks for Relay connections.
         # Relay handles its own certificate presence and validation entirely in routes.py
         if request.url.path.startswith("/relay"):
-            return await call_next(request)
-
-        # Temporary troubleshooting: Allow anonymous GET requests to /SOAP for WSDL probing
-        if request.method == "GET" and request.url.path.lower().startswith("/soap"):
-            print(
-                f"MTLS Middleware: Troubleshooting - Allowing anonymous GET request to {request.url.path} (Query: {request.url.query})",
-                flush=True,
-            )
             return await call_next(request)
 
         client_cert = request.headers.get("X-ARR-ClientCert")

--- a/app/pds/pds.py
+++ b/app/pds/pds.py
@@ -39,7 +39,9 @@ async def lookup_patient(nhsno: int, request: fastapi.Request = None):
             logging.error(
                 f"Failed to retrieve PDS access token. NHS API Response: {r.text}"
             )
-            raise Exception(f"PDS Token Retrieval Error: {r.text}")
+            raise fastapi.HTTPException(
+                status_code=500, detail="NHS API Authentication Failed"
+            )
 
         nhs_token = response_dict["access_token"]
 

--- a/app/pds/pds.py
+++ b/app/pds/pds.py
@@ -21,10 +21,10 @@ router = fastapi.APIRouter(prefix="/pds")
 
 
 @router.get("/lookup_patient/{nhsno}")
-async def lookup_patient(nhsno: int):
-    def get_pds_token():
+async def lookup_patient(nhsno: int, request: fastapi.Request = None):
+    def get_pds_token(kid: str):
         full_path = f"{INT_BASE_PATH}oauth2/token"
-        jwt_token = pds_jwt(API_KEY, API_KEY, full_path, "test-1")
+        jwt_token = pds_jwt(API_KEY, API_KEY, full_path, kid)
         # print(f"jwt_token: {jwt_token}")
 
         oauth_params = {
@@ -50,7 +50,12 @@ async def lookup_patient(nhsno: int):
 
     if not redis_client.exists("access_token"):
         logging.info("NHS token expired or not found, getting new one")
-        nhs_token = get_pds_token()
+        # Extract dynamically generated Key ID, fallback to 'test-1'
+        kid = "test-1"
+        if hasattr(request.app.state, "jwk_json") and request.app.state.jwk_json:
+            kid = request.app.state.jwk_json.get("kid", "test-1")
+
+        nhs_token = get_pds_token(kid)
     else:
         logging.info("NHS token found in cache")
         nhs_token = redis_client.get("access_token").decode("utf-8")

--- a/app/soap/soap.py
+++ b/app/soap/soap.py
@@ -128,23 +128,6 @@ def register_handlers(app: FastAPI):
         )
 
 
-@router.get("/iti55")
-async def iti55_wsdl(request: Request):
-    """
-    Dummy endpoint for WSDL probing troubleshooting.
-    Epic may attempt to do an anonymous GET /SOAP/iti55?wsdl
-    """
-    print(
-        f"Troubleshooting: Received GET on /SOAP/iti55. Query params: {request.query_params}",
-        flush=True,
-    )
-    return Response(
-        content="<wsdl:definitions xmlns:wsdl='http://schemas.xmlsoap.org/wsdl/'></wsdl:definitions>",
-        media_type="application/xml",
-        status_code=200,
-    )
-
-
 @router.post("/iti55")
 async def iti55(request: Request):
     """

--- a/app/soap/soap.py
+++ b/app/soap/soap.py
@@ -192,7 +192,7 @@ async def iti55(request: Request):
             )
             return Response(content=data, media_type="application/soap+xml")
 
-        patient = await lookup_patient(nhsno)
+        patient = await lookup_patient(nhsno, request=request)
         # TODO implement checking of demographics
 
         if (not patient) or (
@@ -286,7 +286,7 @@ async def iti47(request: Request):
         print(f"Mapping NHSNO to CEID: {nhsno} -> {ceid}")
         client.set(ceid, nhsno)
         # TODO add audit stuff here too
-        patient = await lookup_patient(nhsno)
+        patient = await lookup_patient(nhsno, request=request)
         print(f"Patient: {patient}")
         if not patient:
             print("Patient not found")


### PR DESCRIPTION
This PR introduces a fully NHS-compliant, dynamic JWKS endpoint to solve the public_key error caused by the deprecation of the NHS mock-jwks URL, and strips out temporary diagnostic code.

Key Changes:

    NHS JWKS Formatting: Updated the existing /jwk endpoint to properly format the public key inside a {"keys": [...]} array, and added the mandatory alg (RS512) and use (sig) fields required by the NHS API.
    Dynamic Key Rotation: Updated app/pds/pds.py to dynamically fetch the Key ID (kid) mathematically generated from JWTKEY, eliminating the hardcoded "test-1" value. This enables seamless, zero-downtime key rotation in Azure without code changes.
    Troubleshooting Cleanup: Removed the temporary WSDL probing dummy endpoint (GET /iti55), deleted the mTLS bypass rules, and stripped the verbose certificate chain print() logging from mtls.py to prepare the service for production traffic.
    PDS Exception Refactoring: Replaced the bare Python Exception in PDS token retrieval with a clean FastAPI HTTPException(status_code=500) while preserving the background logging.error.
