### PR TITLE
Fix/pentest findings

### DIFF
--- a/app/security.py
+++ b/app/security.py
@@ -171,10 +171,10 @@ def create_jwt(
                 },
                 {
                     "system": "2.16.840.1.113883.2.1.4",
-                    "value": audit.organization_id,
+                    "value": audit.organization_id or "Unknown",
                 },
             ],
-            "name": audit.organization,
+            "name": audit.organization or "Unknown Organization",
         },
         "requesting_practitioner": {
             "resourceType": "Practitioner",
@@ -189,7 +189,7 @@ def create_jwt(
                     "value": "UNK",  # As per NHS spec when not using NHS smartcard
                 },
                 {
-                    "system": audit.organization,
+                    "system": audit.organization or "Unknown Organization",
                     "value": subject_id_str,
                 },
             ],
@@ -207,8 +207,8 @@ def create_jwt(
     # audit_role.pop("nullFlavor", None)  # Remove null flavor if present
 
     audit_role = {
-        "system": audit.role.codeSystemName,
-        "value": audit.role.code,
+        "system": audit.role.codeSystemName if audit.role else "Unknown",
+        "value": audit.role.code if audit.role else "Unknown",
     }
 
     # print("Adding role to JWT payload:", audit_role)

--- a/app/security.py
+++ b/app/security.py
@@ -136,10 +136,16 @@ def create_jwt(
 
     """
     created_time = int(time())
-    family, given = audit.subject_id.split(", ")
+    
+    subject_id_str = audit.subject_id or "Unknown, User"
+    try:
+        family, given = subject_id_str.split(", ", 1)
+    except ValueError:
+        family, given = subject_id_str, "User"
+        
     payload = {
         "iss": "http://int.apis.ptl.api.platform.nhs.uk/Device/EA2027FD-B486-4033-B48C-E87222F6FA1C",
-        "sub": audit.subject_id,
+        "sub": subject_id_str,
         "aud": audience,
         "iat": created_time,
         "exp": created_time + 300,
@@ -172,7 +178,7 @@ def create_jwt(
         },
         "requesting_practitioner": {
             "resourceType": "Practitioner",
-            "id": audit.subject_id,
+            "id": subject_id_str,
             "identifier": [
                 {
                     "system": "https://fhir.nhs.uk/Id/sds-user-id",
@@ -184,7 +190,7 @@ def create_jwt(
                 },
                 {
                     "system": audit.organization,
-                    "value": audit.subject_id,
+                    "value": subject_id_str,
                 },
             ],
             "name": [

--- a/app/security.py
+++ b/app/security.py
@@ -136,13 +136,13 @@ def create_jwt(
 
     """
     created_time = int(time())
-    
+
     subject_id_str = audit.subject_id or "Unknown, User"
     try:
         family, given = subject_id_str.split(", ", 1)
     except ValueError:
         family, given = subject_id_str, "User"
-        
+
     payload = {
         "iss": "http://int.apis.ptl.api.platform.nhs.uk/Device/EA2027FD-B486-4033-B48C-E87222F6FA1C",
         "sub": subject_id_str,

--- a/app/soap/soap.py
+++ b/app/soap/soap.py
@@ -162,9 +162,10 @@ async def iti55(request: Request):
         except (KeyError, TypeError):
             assertion = {}
 
-        trusted_issuer = os.getenv(
+        trusted_issuers_env = os.getenv(
             "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
         )
+        trusted_issuers = [i.strip() for i in trusted_issuers_env.split("|")]
 
         issuer_obj = assertion.get("Issuer")
         if isinstance(issuer_obj, list):
@@ -181,7 +182,7 @@ async def iti55(request: Request):
         # Prevent log injection (CWE-117) and strip whitespace
         issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
 
-        if issuer_str != trusted_issuer:
+        if issuer_str not in trusted_issuers:
             print(
                 f"ITI-55 SAML Verification: Rejected issuer '{issuer_str}'",
                 flush=True,
@@ -322,9 +323,10 @@ async def iti47(request: Request):
         except (KeyError, TypeError):
             assertion = {}
 
-        trusted_issuer = os.getenv(
+        trusted_issuers_env = os.getenv(
             "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
         )
+        trusted_issuers = [i.strip() for i in trusted_issuers_env.split("|")]
 
         issuer_obj = assertion.get("Issuer")
         if isinstance(issuer_obj, list):
@@ -341,7 +343,7 @@ async def iti47(request: Request):
         # Prevent log injection (CWE-117) and strip whitespace
         issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
 
-        if issuer_str != trusted_issuer:
+        if issuer_str not in trusted_issuers:
             print(
                 f"ITI-47 SAML Verification: Rejected issuer '{issuer_str}'",
                 flush=True,
@@ -425,9 +427,10 @@ async def iti38(request: Request):
         except (KeyError, TypeError):
             assertion = {}
 
-        trusted_issuer = os.getenv(
+        trusted_issuers_env = os.getenv(
             "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
         )
+        trusted_issuers = [i.strip() for i in trusted_issuers_env.split("|")]
 
         issuer_obj = assertion.get("Issuer")
         if isinstance(issuer_obj, list):
@@ -444,7 +447,7 @@ async def iti38(request: Request):
         # Prevent log injection (CWE-117) and strip whitespace
         issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
 
-        if issuer_str != trusted_issuer:
+        if issuer_str not in trusted_issuers:
             print(
                 f"ITI-38 SAML Verification: Rejected issuer '{issuer_str}'",
                 flush=True,
@@ -552,9 +555,10 @@ async def iti39(request: Request):
         except (KeyError, TypeError):
             assertion = {}
 
-        trusted_issuer = os.getenv(
+        trusted_issuers_env = os.getenv(
             "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
         )
+        trusted_issuers = [i.strip() for i in trusted_issuers_env.split("|")]
 
         issuer_obj = assertion.get("Issuer")
         if isinstance(issuer_obj, list):
@@ -571,7 +575,7 @@ async def iti39(request: Request):
         # Prevent log injection (CWE-117) and strip whitespace
         issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
 
-        if issuer_str != trusted_issuer:
+        if issuer_str not in trusted_issuers:
             print(
                 f"ITI-39 SAML Verification: Rejected issuer '{issuer_str}'",
                 flush=True,

--- a/app/soap/soap.py
+++ b/app/soap/soap.py
@@ -154,6 +154,40 @@ async def iti55(request: Request):
         body = await request.body()
         envelope = clean_soap(body)
 
+        # Safely extract assertion (prevent unhandled KeyError)
+        try:
+            assertion = envelope["Header"]["Security"]["Assertion"]
+            if isinstance(assertion, list):
+                assertion = assertion[0]
+        except (KeyError, TypeError):
+            assertion = {}
+
+        trusted_issuer = os.getenv(
+            "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
+        )
+
+        issuer_obj = assertion.get("Issuer")
+        if isinstance(issuer_obj, list):
+            issuer_obj = issuer_obj[0]
+
+        issuer_str = (
+            issuer_obj.get("#text", "")
+            if isinstance(issuer_obj, dict)
+            else str(issuer_obj)
+            if issuer_obj is not None
+            else ""
+        )
+
+        # Prevent log injection (CWE-117) and strip whitespace
+        issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
+
+        if issuer_str != trusted_issuer:
+            print(
+                f"ITI-55 SAML Verification: Rejected issuer '{issuer_str}'",
+                flush=True,
+            )
+            raise HTTPException(status_code=401, detail="Invalid SAML Assertion Issuer")
+
         # Safely extract query params to handle fuzzing/malformed payloads
         try:
             query_params = envelope["Body"]["PRPA_IN201305UV02"]["controlActProcess"][
@@ -279,6 +313,40 @@ async def iti47(request: Request):
     if "application/soap+xml" in content_type:
         body = await request.body()
         envelope = clean_soap(body)
+
+        # Safely extract assertion (prevent unhandled KeyError)
+        try:
+            assertion = envelope["Header"]["Security"]["Assertion"]
+            if isinstance(assertion, list):
+                assertion = assertion[0]
+        except (KeyError, TypeError):
+            assertion = {}
+
+        trusted_issuer = os.getenv(
+            "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
+        )
+
+        issuer_obj = assertion.get("Issuer")
+        if isinstance(issuer_obj, list):
+            issuer_obj = issuer_obj[0]
+
+        issuer_str = (
+            issuer_obj.get("#text", "")
+            if isinstance(issuer_obj, dict)
+            else str(issuer_obj)
+            if issuer_obj is not None
+            else ""
+        )
+
+        # Prevent log injection (CWE-117) and strip whitespace
+        issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
+
+        if issuer_str != trusted_issuer:
+            print(
+                f"ITI-47 SAML Verification: Rejected issuer '{issuer_str}'",
+                flush=True,
+            )
+            raise HTTPException(status_code=401, detail="Invalid SAML Assertion Issuer")
 
         query_params = envelope["Body"]["PRPA_IN201305UV02"]["controlActProcess"][
             "queryByParameter"
@@ -475,6 +543,40 @@ async def iti39(request: Request):
         body = await request.body()
         soap = extract_soap_request(body.decode("utf-8"))
         envelope = clean_soap(soap)
+
+        # Safely extract assertion (prevent unhandled KeyError)
+        try:
+            assertion = envelope["Header"]["Security"]["Assertion"]
+            if isinstance(assertion, list):
+                assertion = assertion[0]
+        except (KeyError, TypeError):
+            assertion = {}
+
+        trusted_issuer = os.getenv(
+            "SAML_TRUSTED_ISSUER", "urn:nhs:names:services:spine"
+        )
+
+        issuer_obj = assertion.get("Issuer")
+        if isinstance(issuer_obj, list):
+            issuer_obj = issuer_obj[0]
+
+        issuer_str = (
+            issuer_obj.get("#text", "")
+            if isinstance(issuer_obj, dict)
+            else str(issuer_obj)
+            if issuer_obj is not None
+            else ""
+        )
+
+        # Prevent log injection (CWE-117) and strip whitespace
+        issuer_str = issuer_str.replace("\n", "").replace("\r", "").strip()
+
+        if issuer_str != trusted_issuer:
+            print(
+                f"ITI-39 SAML Verification: Rejected issuer '{issuer_str}'",
+                flush=True,
+            )
+            raise HTTPException(status_code=401, detail="Invalid SAML Assertion Issuer")
         message_id = envelope["Header"]["MessageID"]
         try:
             document_id = envelope["Body"]["RetrieveDocumentSetRequest"][

--- a/app/tests/test_soap_security.py
+++ b/app/tests/test_soap_security.py
@@ -38,7 +38,7 @@ def test_iti38_accepts_valid_saml_issuer(monkeypatch):
 def test_iti39_rejects_ssrf_reply_to(monkeypatch):
     monkeypatch.setenv("REQUIRE_MTLS", "false")
     monkeypatch.setattr("app.soap.soap.client.get", lambda x: b"dummy")
-    ssrf_soap_xml = """<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing"><s:Header><wsa:MessageID>urn:uuid:12345678</wsa:MessageID><wsa:ReplyTo><wsa:Address>http://internal-metadata-server.local/pwned</wsa:Address></wsa:ReplyTo></s:Header><s:Body><RetrieveDocumentSetRequest><DocumentRequest><DocumentUniqueId>123</DocumentUniqueId></DocumentRequest></RetrieveDocumentSetRequest></s:Body></s:Envelope>"""
+    ssrf_soap_xml = """<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing"><s:Header><wsa:MessageID>urn:uuid:12345678</wsa:MessageID><wsa:ReplyTo><wsa:Address>http://internal-metadata-server.local/pwned</wsa:Address></wsa:ReplyTo><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:Issuer>urn:nhs:names:services:spine</saml2:Issuer></saml2:Assertion></wsse:Security></s:Header><s:Body><RetrieveDocumentSetRequest><DocumentRequest><DocumentUniqueId>123</DocumentUniqueId></DocumentRequest></RetrieveDocumentSetRequest></s:Body></s:Envelope>"""
     response = client.post(
         "/SOAP/iti39",
         content=ssrf_soap_xml,
@@ -51,7 +51,7 @@ def test_iti39_rejects_ssrf_reply_to(monkeypatch):
 def test_iti39_accepts_valid_reply_to(monkeypatch):
     monkeypatch.setenv("REQUIRE_MTLS", "false")
     monkeypatch.setattr("app.soap.soap.client.get", lambda x: b"dummy")
-    valid_soap_xml = """<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing"><s:Header><wsa:MessageID>urn:uuid:12345678</wsa:MessageID><wsa:ReplyTo><wsa:Address>https://allowed-domain.nhs.uk/callback</wsa:Address></wsa:ReplyTo></s:Header><s:Body><RetrieveDocumentSetRequest><DocumentRequest><DocumentUniqueId>123</DocumentUniqueId></DocumentRequest></RetrieveDocumentSetRequest></s:Body></s:Envelope>"""
+    valid_soap_xml = """<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing"><s:Header><wsa:MessageID>urn:uuid:12345678</wsa:MessageID><wsa:ReplyTo><wsa:Address>https://allowed-domain.nhs.uk/callback</wsa:Address></wsa:ReplyTo><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:Issuer>urn:nhs:names:services:spine</saml2:Issuer></saml2:Assertion></wsse:Security></s:Header><s:Body><RetrieveDocumentSetRequest><DocumentRequest><DocumentUniqueId>123</DocumentUniqueId></DocumentRequest></RetrieveDocumentSetRequest></s:Body></s:Envelope>"""
     response = client.post(
         "/SOAP/iti39",
         content=valid_soap_xml,


### PR DESCRIPTION
# Pull Request: Pentest Findings & Clinical Safety Fixes

## Description
This PR addresses several vulnerabilities and edge-case bugs discovered during active penetration testing of the SOAP endpoints (ITI-55 and ITI-38), and updates the DCB0129 clinical safety test (XH-040) to support future development.

## Changes Made

### SOAP / XML Parsing Fixes
* **Fix NHS Number Extraction:** Handled a quirk in `xmltodict` where single `<value>` tags were being incorrectly parsed as dictionaries rather than lists, which previously caused the backend to fail extracting the NHS number from perfectly valid payloads.
* **ITI-38 SAML Verification:** Added `.strip()` to the SAML Issuer extraction logic to gracefully ignore accidental whitespace or carriage returns introduced by manual XML payloads.
* **Fix Pydantic Validation & SAML Parsing:** Added default values to SAMLAttributes Optional fields in `models.py` to prevent 500 errors when attributes are omitted (this also ensures Audit Logs are preserved instead of dropping malformed requests). Also fixed a bug in `audit.py` where a single `<Attribute>` tag would be incorrectly parsed as a dict instead of a list.

### Error Handling & Schema Compliance 
* **Prevent 500 Crashes on Malformed XML:** Fixed a bug in `helpers.py` (`clean_soap`) where completely invalid XML sent to any SOAP endpoint would trigger an unhandled `xml.etree.ElementTree.ParseError` and crash the server with a 500. It now safely catches the error and returns a 400 Bad Request (`Malformed XML in request body`).
* **Remediate XXE / Billion Laughs Vulnerability:** Replaced the standard Python `xml.etree.ElementTree` parser with the secure `defusedxml` equivalent in `helpers.py`. This resolves a CodeQL High severity finding (CWE-611 / CWE-776) where parsing user-provided XML without guarding against uncontrolled entity expansion left the API susceptible to denial-of-service and external entity injection attacks.
* **Enforce SAML Validation Across All Endpoints:** Implemented strict SAML assertion validation (`saml2:Issuer` checking) on the `ITI-39`, `ITI-47`, and `ITI-55` endpoints. Previously, only `ITI-38` enforced SAML validation while the others silently ignored missing or invalid SAML assertions. This guarantees full SCAL/NHS compliance across the entire API surface.
* **Support Multiple SAML Issuers:** Updated the SAML validation logic across all endpoints to parse `SAML_TRUSTED_ISSUER` as a pipe-separated (`|`) list. This allows the API to seamlessly support Epic-specific certificate names (e.g. `CN=mychart-np...`) alongside the default Spine issuer without commas in the CN string causing parsing errors.
* **Robust JWT Payload Generation:** Hardened `security.py` against sparse SAML assertions (e.g., from Epic or custom testing tools). Missing attributes like `subject_id`, `role`, or `organization` will now safely default to generic values (e.g. `"Unknown, User"` or `"Unknown Organization"`) instead of throwing `AttributeError` exceptions and causing 500 Internal Server Errors during JWT generation.
* **Prevent ITI-38 Crashes on Missing NHS Number:** Fixed an `UnboundLocalError` bug in `soap.py` where a payload completely lacking a valid NHS number format would fail to assign the `data` variable and crash with a 500. It now safely raises an HTTP 400 Bad Request.
* **Prevent ITI-38 Fuzzing Crashes:** Added safe `.get()` dictionary lookups for `AttributeStatement`, `AdhocQueryRequest`, and `CrossGatewayQuery` elements. The endpoint previously threw 500 `KeyErrors` if these tags were omitted or named differently in alternative mock payloads.
* **Unmask Upstream GP Connect Errors in ITI-38:** Corrected the scope of a `try/except` block in `soap.py` that was overly broad. Previously, any valid NHS number request that subsequently threw a `TypeError` or `AttributeError` during the GP Connect FHIR retrieval process was inadvertently caught and misreported as an `Invalid NHS number format` (HTTP 400). GP Connect errors are now properly permitted to bubble up and return the correct SOAP `XDSRegistryError` fault.
* **Fix Malformed ITI-55 XML Errors:** Corrected a bug where the `message_id`, `error_text`, and `query` arguments were being passed in the wrong order to `iti_55_error`. This previously caused Xhuma to return garbled, schema-violating XML when a patient was not found or had restricted access. 
* **Safe Key Extraction:** Added `.get()` fallbacks for extracting `queryId` and other XML structures to prevent internal 500 `KeyError` crashes during heavy fuzzing.

### Privacy & Logging
* **Fix CodeQL Findings (PHI Logging):** Removed clear-text logging of the `nhsno` and `patient_id` in `gpconnect.py`, `responses.py`, and `soap.py` to ensure patient identifiers are not written in plaintext to the unstructured error logs. CodeQL additionally flagged a tainted variable case where the NHS number was embedded in an internal error string (`r["error"]`) and later logged; this error string has been scrubbed of the PHI.

### Clinical Safety (DCB0129)
* **Refactored XH-040 / T-24:** Updated the clinical safety automated test to be less of a blunt instrument. The test now correctly asserts that **core domains** (Allergies, Medications, Problems) are never silently filtered by date/status (satisfying the hazard), but leaves the door open to apply safe time-boxing filters for high-volume domains (like Investigations) in the future to prevent GP Connect timeouts.

### Housekeeping
* Ran `ruff` formatting and all `pre-commit` hooks to ensure CI compliance.

## Verification
- [x] Tested parsing of single-element XML payloads.
- [x] Verified ITI-55 error responses are well-formed XML.
- [x] `pytest app/tests/test_gp_connect_config.py` passes successfully.
- [x] CI linters pass locally.
